### PR TITLE
An haproxy managaer

### DIFF
--- a/shuttle/shuttle.go
+++ b/shuttle/shuttle.go
@@ -146,7 +146,9 @@ REDO:
 }
 
 func main() {
-	// TODO check for running haproxy instead of restarating every time.
-	restartHaproxy()
+	if !haproxyRunning() {
+		restartHaproxy()
+	}
+
 	watchConfig()
 }


### PR DESCRIPTION
- This takes a single hostname or address for the etcd cluster. Upon
  connecting to the cluster, it's queried to get a list of actual
  participating ip address.
- This directly controls the haproxy process, so that it can make
  certain that updates are applied correctly.
- Build a backend config based on the state of the env tree in etcd.
- Watch the tree for changes, apply them to the backend.cfg and properly
  restart haproxy.
- TODO
  - improve process management for haprox
  - test if we need to periodically kill the watch to make certain we're
    not waiting on a dead connection.
