### PR TITLE
Make our tests pass!

### DIFF
--- a/shuttle/server_test.go
+++ b/shuttle/server_test.go
@@ -36,7 +36,7 @@ func NewTestServer(addr string, c Tester) (*testServer, error) {
 	}
 
 	s.addr = s.listener.Addr().String()
-	c.Log("listning on", s.addr)
+	c.Log("listning on ", s.addr)
 
 	s.wg.Add(1)
 	go func() {


### PR DESCRIPTION
- We were racing the backend connections in the tests, and the LeastConn
  test needs to be deterministicly distibuted. waiting for a call and
  reply in the tests ensures that the connection is complete.
