### PR TITLE
Fix old containers not getting removed on re-deploys

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -115,7 +115,7 @@ func restartContainers(changedConfigs chan *registry.ConfigChange) {
 					changedConfig.ServiceConfig.Version(), err)
 				continue
 			}
-			log.Printf("Restarted %s as: %s\n", changedConfig.ServiceConfig.Version(), container.ID)
+			log.Printf("Restarted %s as: %s\n", changedConfig.ServiceConfig.Version(), container.ID[0:12])
 
 			err = serviceRuntime.StopAllButLatest(stopCutoff)
 			if err != nil {


### PR DESCRIPTION
When deploying by updating the "latest" tag in the registry,
old containers would get left running because they would
become unassociated with the registry tag and commander would
ignore them.  This changes that to rely on the container name
and image ID which should be more reliable to determining if
a container should be running or not.
