### PR TITLE
Use HOME env var instead of user.Current()

### DIFF
--- a/galaxy.go
+++ b/galaxy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -418,14 +417,14 @@ func login(c *cli.Context) {
 		return
 	}
 
-	currentUser, err := user.Current()
-	if err != nil {
-		log.Printf("ERROR: Unable to determine current user: %s\n", err)
+	homeDir := utils.HomeDir()
+	if homeDir == "" {
+		log.Println("ERROR: Unable to determine current home dir. Set $HOME.")
 		return
 	}
 
-	configDir := filepath.Join(currentUser.HomeDir, ".galaxy")
-	_, err = os.Stat(configDir)
+	configDir := filepath.Join(homeDir, ".galaxy")
+	_, err := os.Stat(configDir)
 	if err != nil && os.IsNotExist(err) {
 		os.Mkdir(configDir, 0700)
 	}
@@ -447,14 +446,16 @@ func login(c *cli.Context) {
 
 func logout(c *cli.Context) {
 	initRegistry(c)
-	currentUser, err := user.Current()
-	if err != nil {
-		log.Printf("ERROR: Unable to determine current user: %s\n", err)
+
+	homeDir := utils.HomeDir()
+	if homeDir == "" {
+		log.Println("ERROR: Unable to determine current home dir. Set $HOME")
 		return
 	}
-	configFile := filepath.Join(currentUser.HomeDir, ".galaxy", "galaxy.toml")
 
-	_, err = os.Stat(configFile)
+	configFile := filepath.Join(homeDir, ".galaxy", "galaxy.toml")
+
+	_, err := os.Stat(configFile)
 	if err == nil {
 		err = os.Remove(configFile)
 		if err != nil {
@@ -517,14 +518,15 @@ func runRemote() {
 
 func loadConfig() {
 
-	currentUser, err := user.Current()
-	if err != nil {
-		log.Printf("ERROR: Unable to determine current user: %s\n", err)
+	homeDir := utils.HomeDir()
+	if homeDir == "" {
+		log.Println("ERROR: Unable to determine current home dir. Set $HOME.")
 		return
 	}
-	configFile := filepath.Join(currentUser.HomeDir, ".galaxy", "galaxy.toml")
 
-	_, err = os.Stat(configFile)
+	configFile := filepath.Join(homeDir, ".galaxy", "galaxy.toml")
+
+	_, err := os.Stat(configFile)
 	if err == nil {
 		if _, err := toml.DecodeFile(configFile, &config); err != nil {
 			log.Printf("ERROR: Unable to logout: %s\n", err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"os/user"
 	"strings"
 	"time"
 
@@ -459,13 +458,13 @@ func (s *ServiceRuntime) PullImage(version string, force bool) (*docker.Image, e
 		pullOpts.Repository = registry + "/" + repository
 		pullOpts.Registry = registry
 
-		currentUser, err := user.Current()
-		if err != nil {
-			panic(err)
+		homeDir := utils.HomeDir()
+		if homeDir == "" {
+			return nil, errors.New("ERROR: Unable to determine current home dir. Set $HOME")
 		}
 
 		// use ~/.dockercfg
-		authConfig, err := auth.LoadConfig(currentUser.HomeDir)
+		authConfig, err := auth.LoadConfig(homeDir)
 		if err != nil {
 			panic(err)
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -90,3 +90,7 @@ func GetEnv(name, defaultValue string) string {
 	}
 	return os.Getenv(name)
 }
+
+func HomeDir() string {
+	return os.Getenv("HOME")
+}


### PR DESCRIPTION
user.Current() does not work w/ cross-compiling.  HOME is not always
correctly but it should be good enough for now.  If this doesn't
work out, we can define a separate config environment variable
as well.
