### PR TITLE
Always pull image when config has changed

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -110,6 +110,13 @@ func restartContainers(changedConfigs chan *registry.ConfigChange) {
 				continue
 			}
 
+			_, err := serviceRuntime.PullImage(changedConfig.ServiceConfig.Version(), true)
+			if err != nil {
+				log.Printf("ERROR: Could not pull image %s: %s\n",
+					changedConfig.ServiceConfig.Version(), err)
+				continue
+			}
+
 			log.Printf("Restarting %s\n", changedConfig.ServiceConfig.Name)
 			container, err := serviceRuntime.Start(changedConfig.ServiceConfig)
 			if err != nil {


### PR DESCRIPTION
This should fix auto-deploys and allow us to use docker caching
again when deploying images.  Auto-deploys were actually pulling
the image on the build node and not the runtime nodes because
galaxy was running in local mode and configured w/ the envs
redis instance.  When the deploy completed, the runtime nodes
just recreated the container w/ the same image.

This change forces commander to always pull down the latest image when
it's notified of a config change.
