### PR TITLE
Set  PUBLIC_HOSTNAME env var on containers

### DIFF
--- a/runtime/aws.go
+++ b/runtime/aws.go
@@ -1,0 +1,30 @@
+package runtime
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+)
+
+func ec2PublicHostname() (string, error) {
+	transport := http.Transport{
+		Dial: func(network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, time.Duration(1*time.Second))
+		},
+	}
+
+	client := http.Client{
+		Transport: &transport,
+	}
+	resp, err := client.Get("http://169.254.169.254/latest/meta-data/public-hostname")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}


### PR DESCRIPTION
This can be used by cesta to set the correct upload endpoint.  For
now, it just returns the EC2 public DNS entry but it will eventually
have a evermore.photos CNAME value.  SSL will not work yet but this
should make it possible to upload over HTTP directly to the host.
