### PR TITLE
Use GALAXY_STATSD_HOST env var

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -210,7 +210,7 @@ func main() {
 	flag.StringVar(&pool, "pool", utils.GetEnv("GALAXY_POOL", "web"), "Pool namespace")
 	flag.BoolVar(&loop, "loop", false, "Run continously")
 	flag.StringVar(&shuttleHost, "shuttleAddr", "", "IP where containers can reach shuttle proxy. Defaults to docker0 IP.")
-	flag.StringVar(&statsdHost, "statsdAddr", "", "IP where containers can reach a statsd service. Defaults to docker0 IP:8125.")
+	flag.StringVar(&statsdHost, "statsdAddr", utils.GetEnv("GALAXY_STATSD_HOST", ""), "IP where containers can reach a statsd service. Defaults to docker0 IP:8125.")
 	flag.BoolVar(&debug, "debug", false, "verbose logging")
 	flag.BoolVar(&version, "v", false, "display version info")
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -40,6 +40,8 @@ func NewServiceRuntime(shuttleHost, statsdHost, env, pool, redisHost string) *Se
 		statsdHost = dockerZero + ":8125"
 	}
 
+	statsdHost = utils.GetEnv("GALAXY_STATSD_HOST", statsdHost)
+
 	serviceRegistry := registry.NewServiceRegistry(
 		env,
 		pool,


### PR DESCRIPTION
UDP doesn't seem to work over the docker bridge IP.  We need to
set the GALAXY_STATSD_HOST to the internal IP.  The env var lets
us do it in one place.
