### PR TITLE
Fix deployment notification getting ignored

### DIFF
--- a/registry/notify.go
+++ b/registry/notify.go
@@ -47,6 +47,8 @@ func (r *ServiceRegistry) checkForChanges() {
 		for _, changedConfig := range serviceConfigs {
 			changeCopy := changedConfig
 			if changedConfig.ID() != lastVersion[changedConfig.Name] {
+				log.Printf("%s changed from %d to %d", changedConfig.Name,
+					lastVersion[changedConfig.Name], changedConfig.ID())
 				lastVersion[changedConfig.Name] = changedConfig.ID()
 				restartChan <- &ConfigChange{
 					ServiceConfig: &changeCopy,

--- a/registry/service_config.go
+++ b/registry/service_config.go
@@ -53,9 +53,7 @@ func (s *ServiceConfig) Env() map[string]string {
 }
 
 func (s *ServiceConfig) EnvSet(key, value string) {
-	if s.environmentVMap.Get(key) != value {
-		s.environmentVMap.SetVersion(key, value, s.nextID())
-	}
+	s.environmentVMap.SetVersion(key, value, s.nextID())
 }
 
 func (s *ServiceConfig) EnvGet(key string) string {
@@ -67,9 +65,7 @@ func (s *ServiceConfig) Version() string {
 }
 
 func (s *ServiceConfig) SetVersion(version string) {
-	if s.versionVMap.Get("version") != version {
-		s.versionVMap.SetVersion("version", version, s.nextID())
-	}
+	s.versionVMap.SetVersion("version", version, s.nextID())
 }
 
 func (s *ServiceConfig) Ports() map[string]string {

--- a/registry/service_config_test.go
+++ b/registry/service_config_test.go
@@ -87,8 +87,8 @@ func TestPorts(t *testing.T) {
 func TestID(t *testing.T) {
 	sc := NewServiceConfig("foo", "")
 	id := sc.ID()
-	if id != 0 {
-		t.Fail()
+	if id != 1 {
+		t.Fatalf("id should be 1. Got %d", id)
 	}
 
 	sc.SetVersion("foo")


### PR DESCRIPTION
Deployments changes to the service config were being ignored because
the version that we were setting was always the same.  Deployments
were working because we had a periodic pull or each image and a
check for the running image being different from the latest pulled
one.  
