### PR TITLE
Update stacks

### DIFF
--- a/galaxy.go
+++ b/galaxy.go
@@ -735,6 +735,7 @@ func stackPool(c *cli.Context, create bool) {
 			resources.SecurityGroups["sshSG"],
 			resources.SecurityGroups["defaultSG"],
 		},
+		VolumeSize: 250,
 	}
 
 	if strings.HasPrefix(poolName, "web") {
@@ -770,7 +771,7 @@ func createPool(poolTmpl []byte, stackName string) {
 	if err := stack.Wait(stackName, 5*time.Minute); err != nil {
 		log.Fatal(err)
 	}
-
+	log.Println("CreateStack complete")
 }
 
 func updatePool(poolTmpl []byte, stackName string) {
@@ -783,6 +784,7 @@ func updatePool(poolTmpl []byte, stackName string) {
 		log.Fatal(err)
 	}
 
+	log.Println("UpdateStack complete")
 }
 
 func stackCreatePool(c *cli.Context) {

--- a/stack/galaxy_cloudformation.go
+++ b/stack/galaxy_cloudformation.go
@@ -219,10 +219,6 @@ var cloudformation_template = []byte(`{
                 "AssociatePublicIpAddress": true,
                 "BlockDeviceMappings": [
                     {
-                        "DeviceName": "/dev/sdb",
-                        "VirtualName": "ephemeral0"
-                    },
-                    {
                         "DeviceName": "/dev/sda1",
                         "Ebs": {
                             "VolumeSize": 250

--- a/stack/pool_template.go
+++ b/stack/pool_template.go
@@ -73,13 +73,9 @@ var pool_template = []byte(`
 				"AssociatePublicIpAddress": true,
 				"BlockDeviceMappings": [
 					{
-						"DeviceName": "/dev/sdb",
-						"VirtualName": "ephemeral0"
-					},
-					{
 						"DeviceName": "/dev/sda1",
 						"Ebs": {
-							"VolumeSize": 250
+							"VolumeSize": 8
 						}
 					}
 				],


### PR DESCRIPTION
- Make the default pool disk only 8G, and add a configuration option for
  the final size.
- default galaxy to create pools with 250G disks (for now)
- Remove ephemeral device definitions from the launch configs. Those
  were listed by the cloudformer tool, but I don't know what they
  correspond to.
- Print when stack operations complete so we can see the time in the
  logs.
