### PR TITLE
Remove the ASG UpdatePolicy

### DIFF
--- a/stack/pool.go
+++ b/stack/pool.go
@@ -184,6 +184,15 @@ type asgProp struct {
 	VPCZoneIdentifier       []string
 }
 
+type asgUpdatePolicy struct {
+	AutoScalingRollingUpdate asgUpdate
+}
+
+type asgUpdate struct {
+	MinInstancesInService string
+	MaxBatchSize          string
+	PauseTime             string
+}
 type elb struct {
 	Type       string
 	Properties elbProp
@@ -284,16 +293,6 @@ type ebsDev struct {
 	SnapshotId          string `json:",omitempty"`
 	VolumeSize          int
 	VolumeType          string
-}
-
-type asgUpdatePolicy struct {
-	AutoScalingRollingUpdate asgUpdate
-}
-
-type asgUpdate struct {
-	MinInstancesInService string
-	MaxBatchSize          string
-	PauseTime             string
 }
 
 type tag struct {

--- a/stack/pool_template.go
+++ b/stack/pool_template.go
@@ -25,14 +25,7 @@ var poolTmpl = []byte(`
 				"Tags": [],
 				"VPCZoneIdentifier": []
             },
-			"Type": "AWS::AutoScaling::AutoScalingGroup",
-            "UpdatePolicy" : {
-                "AutoScalingRollingUpdate" : {
-                    "MinInstancesInService" : "1",
-                    "MaxBatchSize" : "1",
-                    "PauseTime" : "PT5M"
-                }
-            }
+			"Type": "AWS::AutoScaling::AutoScalingGroup"
         },
 		"elb_": {
 			"Properties": {


### PR DESCRIPTION
If we want to push an update without dropping instances, we would first
need to run an update to change the policy. If there is already a
policy, and we attemtp to change it, the old policy is the one that
executes.
- Remove the UpdatePolicy by default
- TODO: Create actions to add and remove these in separate StackUpdates
