### PR TITLE
Make the update policy optional

### DIFF
--- a/galaxy.go
+++ b/galaxy.go
@@ -723,6 +723,7 @@ func main() {
 		cli.IntFlag{Name: "desired-size", Usage: "desired pool size"},
 		cli.IntFlag{Name: "http-port", Usage: "instance http port"},
 		cli.BoolFlag{Name: "print", Usage: "print new template and exit"},
+		cli.BoolFlag{Name: "auto-update", Usage: "add an ASG UpdatePolicy"},
 	}
 
 	app := cli.NewApp()

--- a/stack/pool.go
+++ b/stack/pool.go
@@ -2,7 +2,9 @@ package stack
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -149,7 +151,7 @@ func (p *Pool) UnmarshalJSON(b []byte) error {
 type asg struct {
 	Type         string
 	Properties   asgProp
-	UpdatePolicy asgUpdatePolicy `json:",omitempty"`
+	UpdatePolicy *asgUpdatePolicy `json:",omitempty"`
 }
 
 func (a *asg) AddLoadBalancer(name string) {
@@ -193,6 +195,19 @@ type asgUpdate struct {
 	MaxBatchSize          string
 	PauseTime             string
 }
+
+// Generate an ASGUpdatePolicy
+func (a *asg) SetASGUpdatePolicy(min, batch int, pause time.Duration) {
+	a.UpdatePolicy = &asgUpdatePolicy{
+		AutoScalingRollingUpdate: asgUpdate{
+			MinInstancesInService: strconv.Itoa(min),
+			MaxBatchSize:          strconv.Itoa(batch),
+			// XML duration -- close enough for now.
+			PauseTime: "PT" + strings.ToUpper(pause.String()),
+		},
+	}
+}
+
 type elb struct {
 	Type       string
 	Properties elbProp

--- a/stacks.go
+++ b/stacks.go
@@ -354,6 +354,11 @@ func stackCreatePool(c *cli.Context) {
 		asg.Properties.MinSize = minSize
 	}
 
+	if c.Bool("auto-update") {
+		// TODO: configure this somehow
+		asg.SetASGUpdatePolicy(1, 1, 5*time.Minute)
+	}
+
 	pool.Resources[asgName] = asg
 
 	// Optionally create the Elastic Load Balancer
@@ -456,6 +461,11 @@ func stackUpdatePool(c *cli.Context) {
 
 	if c.Int("max-size") > 0 {
 		asg.Properties.MaxSize = c.Int("max-size")
+	}
+
+	if c.Bool("auto-update") {
+		// TODO: configure this somehow
+		asg.SetASGUpdatePolicy(1, 1, 5*time.Minute)
 	}
 
 	elb := pool.ELB()


### PR DESCRIPTION
- This is hairy, since a stack update uses the policy from the
  existing stack if it exists (the template is replaced on successful
  completion). Once you add an UpdatePolicy, the next update will force
  the replacements of the instances even if the policy is removed.
