### PR TITLE
Change http proxy timeout

### DIFF
--- a/shuttle/http.go
+++ b/shuttle/http.go
@@ -117,10 +117,10 @@ func (s *HTTPRouter) AddBackend(name, vhost, url string) error {
 		}
 
 		// Create a http location with the load balancer we've just added
-		loc, err := httploc.NewLocationWithOptions(name, balancer,
-			httploc.Options{
-				TrustForwardHeader: true,
-			})
+		opts := httploc.Options{}
+		opts.TrustForwardHeader = true
+		opts.Timeouts.Read = 60 * time.Second
+		loc, err := httploc.NewLocationWithOptions(name, balancer, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Change http timeout from a fixed deadline, to a rolling idle timeout
  using the connection and listener from the shuttle proxy.
