### PR TITLE
Use HostIp for redis key instead of hostname

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"time"
@@ -56,18 +55,6 @@ func NewServiceRegistry(env, pool, hostIp string, ttl uint64, sshAddr string) *S
 		pollCh:      make(chan bool),
 	}
 
-}
-
-func (r *ServiceRegistry) ensureHostname() string {
-	if r.Hostname == "" {
-		hostname, err := os.Hostname()
-		if err != nil {
-			panic(err)
-		}
-		r.Hostname = hostname
-
-	}
-	return r.Hostname
 }
 
 // Build the Redis Pool

--- a/registry/service_registration.go
+++ b/registry/service_registration.go
@@ -50,7 +50,7 @@ func (s *ServiceRegistration) InternalAddr() string {
 }
 
 func (r *ServiceRegistry) RegisterService(container *docker.Container, serviceConfig *ServiceConfig) (*ServiceRegistration, error) {
-	registrationPath := path.Join(r.Env, r.Pool, "hosts", r.ensureHostname(), serviceConfig.Name)
+	registrationPath := path.Join(r.Env, r.Pool, "hosts", r.HostIP, serviceConfig.Name)
 
 	serviceRegistration := r.newServiceRegistration(container)
 	serviceRegistration.Name = serviceConfig.Name
@@ -85,7 +85,7 @@ func (r *ServiceRegistry) RegisterService(container *docker.Container, serviceCo
 
 func (r *ServiceRegistry) UnRegisterService(container *docker.Container, serviceConfig *ServiceConfig) (*ServiceRegistration, error) {
 
-	registrationPath := path.Join(r.Env, r.Pool, "hosts", r.ensureHostname(), serviceConfig.Name)
+	registrationPath := path.Join(r.Env, r.Pool, "hosts", r.HostIP, serviceConfig.Name)
 
 	conn := r.redisPool.Get()
 	defer conn.Close()
@@ -105,7 +105,7 @@ func (r *ServiceRegistry) UnRegisterService(container *docker.Container, service
 
 func (r *ServiceRegistry) GetServiceRegistration(container *docker.Container, serviceConfig *ServiceConfig) (*ServiceRegistration, error) {
 
-	regPath := path.Join(r.Env, r.Pool, "hosts", r.ensureHostname(), serviceConfig.Name)
+	regPath := path.Join(r.Env, r.Pool, "hosts", r.HostIP, serviceConfig.Name)
 
 	existingRegistration := ServiceRegistration{
 		Path: regPath,


### PR DESCRIPTION
When hosts are scaled up, they can have the same hostname at time
which causes conflicts and overwriting of data in redis.  Use
host ip instead which needs to be unique.

Fixe #111
