### PR TITLE
SetLinger(0)

### DIFF
--- a/shuttle/service.go
+++ b/shuttle/service.go
@@ -379,7 +379,7 @@ func (s *Service) connect(cliConn net.Conn) {
 	// Try the first backend given, but if that fails, cycle through them all
 	// to make a best effort to connect the client.
 	for _, b := range backends {
-		srvConn, err := net.DialTimeout("tcp", b.Addr, b.dialTimeout)
+		srvConn, err := s.dialer.Dial("tcp", b.Addr)
 		if err != nil {
 			log.Errorf("ERROR: connecting to backend %s/%s: %s", s.Name, b.Name, err)
 			atomic.AddInt64(&b.Errors, 1)


### PR DESCRIPTION
- Use SetLinger(0) for tcp health checks where no data is sent or
  received.
- Use SetLinger(0) when proxying a TCP connection, and the client closes
  first, since we can't do anything with any more data from the server.
- fix comment in proxy
- use the pre-declared Service.dialer for tcp proxy connections too

fixes #137, My only concern is that some applications may log (or worse) "connection reset by peer" errors, mostly from TCP health checks, but it also may arise from normal connections where the client aborts. We probably want to watch things for a while if we deploy this.
