### PR TITLE
Allow pools to run in a subset of AZs

### DIFF
--- a/galaxy.go
+++ b/galaxy.go
@@ -769,6 +769,7 @@ func main() {
 		cli.IntFlag{Name: "scale-down-delay", Usage: "minutes to wait for scaling down"},
 		cli.IntFlag{Name: "scale-up-cpu", Usage: "cpu threshold for scaling up"},
 		cli.IntFlag{Name: "scale-down-cpu", Usage: "cpu threshold for scaling down"},
+		cli.IntFlag{Name: "availability-zones", Usage: "number of availability zones to run a pool in"},
 	}
 
 	app := cli.NewApp()

--- a/stack/pool.go
+++ b/stack/pool.go
@@ -180,7 +180,7 @@ func (a *asg) AddTag(key, value string, propagateAtLauch bool) {
 }
 
 type asgProp struct {
-	AvailabilityZones       fnGetAZs
+	AvailabilityZones       []string
 	Cooldown                int `json:",string"`
 	DesiredCapacity         int `json:",string"`
 	HealthCheckGracePeriod  int `json:",string"`

--- a/stack/pool_template.go
+++ b/stack/pool_template.go
@@ -12,9 +12,7 @@ var poolTmpl = []byte(`
     "Resources": {
         "asg_": {
             "Properties": {
-                "AvailabilityZones": {
-                    "Fn::GetAZs": ""
-                },
+                "AvailabilityZones": [],
                 "Cooldown": "300",
 				"DesiredCapacity": "1",
                 "HealthCheckGracePeriod": "300",


### PR DESCRIPTION
- Add DescribeSubnets. We need to have the details so we can generate a
  matching list of availability zones.
- Use all the subnet info in SharedResources
- Change the pool template to list AZs instead if using the intrinsic to
  pull them all.
- Add -availability-zones option. The default number of zones is still
  equal to the number of desired hosts
- rename ListAvailabilityZones -> DescribeAvailabilityZones for
  consistency
