### PR TITLE
Filter "" from virtual_hosts in config

### DIFF
--- a/shuttle/registry.go
+++ b/shuttle/registry.go
@@ -258,7 +258,7 @@ func (s *ServiceRegistry) AddService(svcCfg client.ServiceConfig) error {
 
 	s.svcs[service.Name] = service
 
-	svcCfg.VirtualHosts = filter(svcCfg.VirtualHosts, "")
+	svcCfg.VirtualHosts = filterEmpty(svcCfg.VirtualHosts)
 	for _, name := range svcCfg.VirtualHosts {
 		vhost := s.vhosts[name]
 		if vhost == nil {
@@ -340,7 +340,7 @@ func (s *ServiceRegistry) UpdateService(newCfg client.ServiceConfig) error {
 		service.errorPages.Update(newCfg.ErrorPages)
 	}
 
-	s.updateVHosts(service, filter(newCfg.VirtualHosts, ""))
+	s.updateVHosts(service, filterEmpty(newCfg.VirtualHosts))
 
 	return nil
 }

--- a/shuttle/utils.go
+++ b/shuttle/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 )
 
 // marshal whatever we've got with out default indentation
@@ -24,14 +25,14 @@ func genId() string {
 	return fmt.Sprintf("%x", b)
 }
 
-// remove matching strings from a []string
-func filter(a []string, m string) []string {
+// remove empty strings from a []string
+func filterEmpty(a []string) []string {
 	removed := 0
 	for i := 0; i < len(a); i++ {
 		if removed > 0 {
 			a[i-removed] = a[i]
 		}
-		if a[i] == m {
+		if len(strings.TrimSpace(a[i])) == 0 {
 			removed++
 		}
 


### PR DESCRIPTION
- Prevent adding vhosts with "" and a name
- Make the log message more clear
