### PR TITLE
commander: remove default registry URL

### DIFF
--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -48,6 +48,10 @@ var (
 
 func initOrDie() {
 
+	if registryURL == "" {
+		log.Fatalf("ERROR: Registry URL not specified")
+	}
+
 	serviceRegistry = registry.NewServiceRegistry(
 		registry.DefaultTTL,
 	)
@@ -393,8 +397,7 @@ func monitorService(changedConfigs chan *config.ConfigChange) {
 
 func main() {
 	flag.Int64Var(&stopCutoff, "cutoff", 10, "Seconds to wait before stopping old containers")
-	flag.StringVar(&registryURL, "registry", utils.GetEnv("GALAXY_REGISTRY_URL",
-		"redis://"+utils.DefaultRedisHost), "registry URL")
+	flag.StringVar(&registryURL, "registry", utils.GetEnv("GALAXY_REGISTRY_URL", ""), "registry URL")
 	flag.StringVar(&env, "env", utils.GetEnv("GALAXY_ENV", ""), "Environment namespace")
 	flag.StringVar(&pool, "pool", utils.GetEnv("GALAXY_POOL", ""), "Pool namespace")
 	flag.StringVar(&hostIP, "host-ip", "127.0.0.1", "Host IP")

--- a/galaxy.go
+++ b/galaxy.go
@@ -520,7 +520,7 @@ func main() {
 	app.Usage = "galaxy cli"
 	app.Version = buildVersion
 	app.Flags = []cli.Flag{
-		cli.StringFlag{Name: "registry", Value: "redis://" + utils.DefaultRedisHost, Usage: "host:port[,host:port,..]"},
+		cli.StringFlag{Name: "registry", Value: "", Usage: "host:port[,host:port,..]"},
 		cli.StringFlag{Name: "env", Value: "", Usage: "environment (dev, test, prod, etc.)"},
 		cli.StringFlag{Name: "pool", Value: "", Usage: "pool (web, worker, etc.)"},
 	}

--- a/hud/hud.go
+++ b/hud/hud.go
@@ -47,7 +47,7 @@ func main() {
 	flag.StringVar(&statsPrefix, "statsPrefix", "", "Global prefix for all stats")
 	flag.StringVar(&env, "env", utils.GetEnv("GALAXY_ENV", ""), "Environment namespace")
 	flag.StringVar(&pool, "pool", utils.GetEnv("GALAXY_POOL", ""), "Pool namespace")
-	flag.StringVar(&redisHost, "redis", utils.GetEnv("GALAXY_REDIS_HOST", utils.DefaultRedisHost), "redis host")
+	flag.StringVar(&redisHost, "redis", utils.GetEnv("GALAXY_REDIS_HOST", ""), "redis host")
 	flag.BoolVar(&debug, "debug", false, "Enables debug build")
 	flag.BoolVar(&version, "v", false, "display version info")
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,12 +21,6 @@ func (s *SliceVar) String() string {
 	return strings.Join(*s, ",")
 }
 
-const (
-	DefaultRedisHost = "127.0.0.1:6379"
-	DefaultEnv       = ""
-	DefaultPool      = ""
-)
-
 type OutputBuffer struct {
 	Output []string
 }
@@ -112,24 +106,25 @@ func HomeDir() string {
 }
 
 func GalaxyEnv(c *cli.Context) string {
-	if c.GlobalString("env") != DefaultEnv {
+	if c.GlobalString("env") != "" {
 		return strings.TrimSpace(c.GlobalString("env"))
 	}
-	return strings.TrimSpace(GetEnv("GALAXY_ENV", c.GlobalString("env")))
+	return strings.TrimSpace(GetEnv("GALAXY_ENV", ""))
 }
 
 func GalaxyPool(c *cli.Context) string {
-	if c.GlobalString("pool") != DefaultPool {
+	if c.GlobalString("pool") != "" {
 		return strings.TrimSpace(c.GlobalString("pool"))
 	}
-	return strings.TrimSpace(GetEnv("GALAXY_POOL", c.GlobalString("pool")))
+	return strings.TrimSpace(GetEnv("GALAXY_POOL", ""))
 }
 
 func GalaxyRedisHost(c *cli.Context) string {
-	if c.GlobalString("registry") != DefaultRedisHost {
+	if c.GlobalString("registry") != "" {
 		return strings.TrimSpace(c.GlobalString("registry"))
 	}
-	return strings.TrimSpace(GetEnv("GALAXY_REGISTRY_URL", c.GlobalString("registry")))
+
+	return strings.TrimSpace(GetEnv("GALAXY_REGISTRY_URL", ""))
 }
 
 // NextSlot finds the first available index in an array of integers


### PR DESCRIPTION
It was defaulting to a local redis instance.  Now there is no
default and it needs to be set w/ -registry or GALAXY_REGISTRY_URL
env var.
