### PR TITLE
Add CPUShares limit to containers

### DIFF
--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -908,9 +908,12 @@ func main() {
 	case "runtime:set":
 		var ps int
 		var m string
+		var c string
 		runtimeFs := flag.NewFlagSet("runtime:set", flag.ExitOnError)
 		runtimeFs.IntVar(&ps, "ps", 0, "Number of instances to run across all hosts")
 		runtimeFs.StringVar(&m, "m", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
+		runtimeFs.StringVar(&c, "c", "", "CPU shares (relative weight)")
+
 		runtimeFs.Usage = func() {
 			println("Usage: commander runtime:set [-ps 1] <app>\n")
 			println("    Set container runtime policies\n")
@@ -939,8 +942,9 @@ func main() {
 		}
 
 		updated, err := commander.RuntimeSet(configStore, app, env, pool, commander.RuntimeOptions{
-			Ps:     ps,
-			Memory: m,
+			Ps:        ps,
+			Memory:    m,
+			CPUShares: c,
 		})
 		if err != nil {
 			log.Fatalf("ERROR: %s", err)

--- a/commander/runtime.go
+++ b/commander/runtime.go
@@ -1,16 +1,18 @@
 package commander
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/litl/galaxy/config"
 	"github.com/litl/galaxy/log"
 	"github.com/ryanuber/columnize"
-	"strconv"
-	"strings"
 )
 
 type RuntimeOptions struct {
-	Ps     int
-	Memory string
+	Ps        int
+	Memory    string
+	CPUShares string
 }
 
 func RuntimeList(configStore *config.Store, app, env, pool string) error {

--- a/config/app_config.go
+++ b/config/app_config.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/litl/galaxy/utils"
 	"strconv"
 	"strings"
+
+	"github.com/litl/galaxy/utils"
 )
 
 type AppConfig struct {
@@ -155,5 +156,15 @@ func (s *AppConfig) SetMemory(pool string, mem string) {
 
 func (s *AppConfig) GetMemory(pool string) string {
 	key := fmt.Sprintf("%s-mem", pool)
+	return s.runtimeVMap.Get(key)
+}
+
+func (s *AppConfig) SetCPUShares(pool string, cpu string) {
+	key := fmt.Sprintf("%s-cpu", pool)
+	s.runtimeVMap.Set(key, cpu)
+}
+
+func (s *AppConfig) GetCPUShares(pool string) string {
+	key := fmt.Sprintf("%s-cpu", pool)
 	return s.runtimeVMap.Get(key)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -540,6 +540,12 @@ func (s *ServiceRuntime) StartInteractive(env, pool string, appCfg *config.AppCo
 		args = append(args, mem)
 	}
 
+	cpu := appCfg.GetCPUShares(pool)
+	if cpu != "" {
+		args = append(args, "-c")
+		args = append(args, cpu)
+	}
+
 	args = append(args, []string{"-t", appCfg.Version(), "/bin/bash"}...)
 	// shell out to docker run to get signal forwarded and terminal setup correctly
 	//cmd := exec.Command("docker", "run", "-rm", "-i", "-t", appCfg.Version(), "/bin/bash")
@@ -644,6 +650,13 @@ func (s *ServiceRuntime) Start(env, pool string, appCfg *config.AppConfig) (*doc
 				return nil, err
 			}
 			config.Memory = m
+		}
+
+		cpu := appCfg.GetCPUShares(pool)
+		if cpu != "" {
+			if c, err := strconv.Atoi(cpu); err == nil {
+				config.CPUShares = int64(c)
+			}
 		}
 
 		log.Printf("Creating %s version %s", appCfg.Name, appCfg.Version())


### PR DESCRIPTION
- Set CPU limits in `commander runtime` with `-c`
- translates directly to `docker run -c`

(memory limits already implemented with `-m`)
