### PR TITLE
Update shuttle version

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -7,5 +7,5 @@ github.com/fatih/color 95b468b5f34882796c597b718955603a584a9bd4
 github.com/fsouza/go-dockerclient bc54f3734b9b098e24680d5ad686f602bc152df4
 github.com/garyburd/redigo 61e2910408efd40dafb3c7d856a4cf8aeb5fb1c6
 github.com/goamz/goamz a1da1b724496ac803aabd4898e15e74535d68ee0
-github.com/litl/shuttle 2e2fd62aa279271bb5b59b064e0843ead26853fd
+github.com/litl/shuttle f2398ad6626694603accb6d34183aedee79336df
 github.com/ryanuber/columnize fef4ee9c9ecfb000e86ca19ac9cea7d58200d5b6


### PR DESCRIPTION
Shuttle client lib has changes since the last release too.
galaxy is probably unaffected, but better off safe.