### PR TITLE
Add "--tags" to the version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY : commander galaxy clean fmt test upload-release
 
 TAG:=`git describe --abbrev=0 --tags`
-LDFLAGS:=-X main.buildVersion `git describe --long`
+LDFLAGS:=-X main.buildVersion `git describe --long --tags`
 
 all: commander galaxy
 


### PR DESCRIPTION
- I used github to add the v0.4.1 tag, which doesn't use an annotated
  tag. Use the --tags option to make sure we pick this up in the release
  version.