### PR TITLE
Fix redis pool handling

### DIFF
--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -476,19 +476,6 @@ func main() {
 		ensureEnv()
 		ensurePool()
 
-		/* //FIXME: Temp fix for #179
-		hosts, err := configStore.ListHosts(env, pool)
-		if err != nil {
-			log.Fatalf("ERROR: %s", err)
-		}
-
-		for _, hi := range hosts {
-			if hi.HostIP == hostIP {
-				log.Fatalf("ERROR: agent already running on this host")
-			}
-		}
-		*/
-
 	case "app":
 		appFs := flag.NewFlagSet("app", flag.ExitOnError)
 		appFs.Usage = func() {


### PR DESCRIPTION
- No need to close the redis pool any time there's an error, the pool
  Dials new connections as needed.
- remove all conn.Close() calls after errors, since the defer already
  calls Close().
- Prevent panics from the multiple calls to Close, and from returning
  connections to a closed pool.
- Fixes panics in #179 