### PR TITLE
Change config.AppConfig to an interface

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -48,7 +48,7 @@ func appBackup(c *cli.Context) {
 		}
 
 		for _, app := range appList {
-			toBackup = append(toBackup, app.Name)
+			toBackup = append(toBackup, app.Name())
 		}
 	}
 
@@ -189,7 +189,7 @@ func appRestore(c *cli.Context) {
 func restoreApp(bkup *appCfg, env string) error {
 	fmt.Println("restoring", bkup.Name)
 
-	var svcCfg *gconfig.AppConfig
+	var svcCfg gconfig.App
 
 	exists, err := configStore.AppExists(bkup.Name, env)
 	if err != nil {

--- a/commander/app.go
+++ b/commander/app.go
@@ -39,7 +39,7 @@ func AppList(configStore *config.Store, env string) error {
 		}
 
 		for _, app := range appList {
-			name := app.Name
+			name := app.Name()
 			versionDeployed := app.Version()
 			versionID := app.VersionID()
 			if len(versionID) > 12 {
@@ -52,7 +52,7 @@ func AppList(configStore *config.Store, env string) error {
 				if err != nil {
 					return err
 				}
-				if utils.StringInSlice(app.Name, aa) {
+				if utils.StringInSlice(app.Name(), aa) {
 					assignments = append(assignments, pool)
 				}
 			}

--- a/commander/runtime.go
+++ b/commander/runtime.go
@@ -41,7 +41,7 @@ func RuntimeList(configStore *config.Store, app, env, pool string) error {
 
 		for _, appCfg := range appList {
 
-			if app != "" && appCfg.Name != app {
+			if app != "" && appCfg.Name() != app {
 				continue
 			}
 
@@ -51,7 +51,7 @@ func RuntimeList(configStore *config.Store, app, env, pool string) error {
 					continue
 				}
 
-				name := appCfg.Name
+				name := appCfg.Name()
 				ps := appCfg.GetProcesses(p)
 				mem := appCfg.GetMemory(p)
 

--- a/config/backend.go
+++ b/config/backend.go
@@ -4,10 +4,10 @@ type Backend interface {
 	// Apps
 	AppExists(app, env string) (bool, error)
 	CreateApp(app, env string) (bool, error)
-	ListApps(env string) ([]*AppConfig, error)
-	GetApp(app, env string) (*AppConfig, error)
-	UpdateApp(svcCfg *AppConfig, env string) (bool, error)
-	DeleteApp(svcCfg *AppConfig, env string) (bool, error)
+	ListApps(env string) ([]App, error)
+	GetApp(app, env string) (App, error)
+	UpdateApp(svcCfg App, env string) (bool, error)
+	DeleteApp(svcCfg App, env string) (bool, error)
 
 	// Pools
 	AssignApp(app, env, pool string) (bool, error)

--- a/config/memory.go
+++ b/config/memory.go
@@ -14,14 +14,14 @@ type Value struct {
 
 type MemoryBackend struct {
 	maps        map[string]map[string]string
-	apps        map[string][]*AppConfig // env -> []app
+	apps        map[string][]App // env -> []app
 	assignments map[string][]string
 
 	AppExistsFunc       func(app, env string) (bool, error)
 	CreateAppFunc       func(app, env string) (bool, error)
-	GetAppFunc          func(app, env string) (*AppConfig, error)
-	UpdateAppFunc       func(svcCfg *AppConfig, env string) (bool, error)
-	DeleteAppFunc       func(svcCfg *AppConfig, env string) (bool, error)
+	GetAppFunc          func(app, env string) (App, error)
+	UpdateAppFunc       func(svcCfg App, env string) (bool, error)
+	DeleteAppFunc       func(svcCfg App, env string) (bool, error)
 	ListAppFunc         func(env string) ([]AppConfig, error)
 	AssignAppFunc       func(app, env, pool string) (bool, error)
 	UnassignAppFunc     func(app, env, pool string) (bool, error)
@@ -43,7 +43,7 @@ type MemoryBackend struct {
 func NewMemoryBackend() *MemoryBackend {
 	return &MemoryBackend{
 		maps:        make(map[string]map[string]string),
-		apps:        make(map[string][]*AppConfig),
+		apps:        make(map[string][]App),
 		assignments: make(map[string][]string),
 	}
 }
@@ -54,7 +54,7 @@ func (r *MemoryBackend) AppExists(app, env string) (bool, error) {
 	}
 
 	for _, s := range r.apps[env] {
-		if s.Name == app {
+		if s.Name() == app {
 			return true, nil
 		}
 	}
@@ -75,38 +75,38 @@ func (r *MemoryBackend) CreateApp(app, env string) (bool, error) {
 	return false, nil
 }
 
-func (r *MemoryBackend) ListApps(env string) ([]*AppConfig, error) {
+func (r *MemoryBackend) ListApps(env string) ([]App, error) {
 	return r.apps[env], nil
 }
 
-func (r *MemoryBackend) GetApp(app, env string) (*AppConfig, error) {
+func (r *MemoryBackend) GetApp(app, env string) (App, error) {
 	if r.GetAppFunc != nil {
 		return r.GetAppFunc(app, env)
 	}
 
 	for _, cfg := range r.apps[env] {
-		if cfg.Name == app {
+		if cfg.Name() == app {
 			return cfg, nil
 		}
 	}
 	return nil, nil
 }
 
-func (r *MemoryBackend) UpdateApp(svcCfg *AppConfig, env string) (bool, error) {
+func (r *MemoryBackend) UpdateApp(svcCfg App, env string) (bool, error) {
 	if r.UpdateAppFunc != nil {
 		return r.UpdateAppFunc(svcCfg, env)
 	}
 	return false, nil
 }
 
-func (r *MemoryBackend) DeleteApp(svcCfg *AppConfig, env string) (bool, error) {
+func (r *MemoryBackend) DeleteApp(svcCfg App, env string) (bool, error) {
 	if r.DeleteAppFunc != nil {
 		return r.DeleteAppFunc(svcCfg, env)
 	}
 
-	cfgs := []*AppConfig{}
+	cfgs := []App{}
 	for _, cfg := range r.apps[env] {
-		if cfg.Name != svcCfg.Name {
+		if cfg.Name() != svcCfg.Name() {
 			cfgs = append(cfgs, cfg)
 		}
 	}

--- a/config/notify.go
+++ b/config/notify.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ConfigChange struct {
-	AppConfig *AppConfig
+	AppConfig App
 	Restart   bool
 	Error     error
 }
@@ -32,7 +32,7 @@ func (r *Store) checkForChanges(env string) {
 		}
 
 		for _, config := range appCfg {
-			lastVersion[config.Name] = config.ID()
+			lastVersion[config.Name()] = config.ID()
 		}
 		break
 
@@ -49,10 +49,10 @@ func (r *Store) checkForChanges(env string) {
 		}
 		for _, changedConfig := range appCfg {
 			changeCopy := changedConfig
-			if changedConfig.ID() != lastVersion[changedConfig.Name] {
+			if changedConfig.ID() != lastVersion[changedConfig.Name()] {
 				log.Printf("%s changed from %d to %d", changedConfig.Name,
-					lastVersion[changedConfig.Name], changedConfig.ID())
-				lastVersion[changedConfig.Name] = changedConfig.ID()
+					lastVersion[changedConfig.Name()], changedConfig.ID())
+				lastVersion[changedConfig.Name()] = changedConfig.ID()
 				restartChan <- &ConfigChange{
 					AppConfig: changeCopy,
 				}

--- a/config/store.go
+++ b/config/store.go
@@ -201,7 +201,7 @@ func (r *Store) DeleteApp(app, env string) (bool, error) {
 	return true, nil
 }
 
-func (r *Store) ListApps(env string) ([]*AppConfig, error) {
+func (r *Store) ListApps(env string) ([]App, error) {
 	return r.Backend.ListApps(env)
 }
 
@@ -209,7 +209,7 @@ func (r *Store) ListEnvs() ([]string, error) {
 	return r.Backend.ListEnvs()
 }
 
-func (r *Store) GetApp(app, env string) (*AppConfig, error) {
+func (r *Store) GetApp(app, env string) (App, error) {
 	exists, err := r.AppExists(app, env)
 	if err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func (r *Store) GetApp(app, env string) (*AppConfig, error) {
 	return r.Backend.GetApp(app, env)
 }
 
-func (r *Store) UpdateApp(svcCfg *AppConfig, env string) (bool, error) {
+func (r *Store) UpdateApp(svcCfg App, env string) (bool, error) {
 	updated, err := r.Backend.UpdateApp(svcCfg, env)
 	if !updated || err != nil {
 		return updated, err


### PR DESCRIPTION
- Most of galaxy currently relies on config.AppConfig, which is directly
  tied to the vmap implementation, which isn't needed for a consistent
  store like consul.
- Change the one public field, Name, to a getter method
- Convert all the galaxy code to use the interface