### PR TITLE
Add pool commands to commander

### DIFF
--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -1043,6 +1043,64 @@ func main() {
 		}
 		return
 
+	case "pool":
+
+		err := commander.ListPools(configStore, env)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+
+	case "pool:create":
+		appFs := flag.NewFlagSet("pool:create", flag.ExitOnError)
+		appFs.Usage = func() {
+			println("Usage: commander -env <env> pool:create <pool>\n")
+			println("    Create a pool in <env>\n")
+			appFs.PrintDefaults()
+		}
+		appFs.Parse(flag.Args()[1:])
+
+		ensureEnv()
+
+		if pool == "" && appFs.NArg() > 0 {
+			pool = appFs.Arg(0)
+		} else {
+			ensurePool()
+		}
+
+		err := commander.PoolCreate(configStore, env, pool)
+		if err != nil {
+			log.Fatalf("ERROR: Could not create pool: %s", err)
+		}
+		fmt.Println("created pool:", pool)
+		return
+
+	case "pool:delete":
+		appFs := flag.NewFlagSet("pool:delete", flag.ExitOnError)
+		appFs.Usage = func() {
+			println("Usage: commander -env <env> pool:delete <pool>\n")
+			println("    Delete a pool from <env>\n")
+			appFs.PrintDefaults()
+		}
+		appFs.Parse(flag.Args()[1:])
+
+		ensureEnv()
+
+		if pool == "" && flag.NArg() > 1 {
+			pool = flag.Arg(1)
+		} else {
+			ensurePool()
+		}
+
+		err := commander.PoolDelete(configStore, env, pool)
+		if err != nil {
+			log.Fatalf("ERROR: Could not delete pool: %s", err)
+			return
+		}
+
+		fmt.Println("deleted pool:", pool)
+		return
+
 	default:
 		fmt.Println("Unknown command")
 		flag.Usage()
@@ -1084,5 +1142,4 @@ func main() {
 
 	// TODO: do we still need a WaitGroup?
 	wg.Wait()
-
 }

--- a/commander/app.go
+++ b/commander/app.go
@@ -68,7 +68,7 @@ func AppList(configStore *config.Store, env string) error {
 		}
 	}
 	output := columnize.SimpleFormat(columns)
-	log.Println(output)
+	fmt.Println(output)
 	return nil
 }
 

--- a/commander/config.go
+++ b/commander/config.go
@@ -34,7 +34,7 @@ func ConfigList(configStore *config.Store, app, env string) error {
 			log.Printf("%s=%s\n", k, env)
 			continue
 		}
-		log.Printf("%s=%s\n", k, cfg.Env()[k])
+		fmt.Printf("%s=%s\n", k, cfg.Env()[k])
 	}
 
 	return nil

--- a/commander/hosts.go
+++ b/commander/hosts.go
@@ -1,10 +1,10 @@
 package commander
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/litl/galaxy/config"
-	"github.com/litl/galaxy/log"
 	"github.com/ryanuber/columnize"
 )
 
@@ -58,7 +58,6 @@ func HostsList(configStore *config.Store, env, pool string) error {
 		}
 	}
 	output := columnize.SimpleFormat(columns)
-	log.Println(output)
+	fmt.Println(output)
 	return nil
-
 }

--- a/commander/pool.go
+++ b/commander/pool.go
@@ -1,0 +1,98 @@
+package commander
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/litl/galaxy/config"
+	"github.com/ryanuber/columnize"
+)
+
+// TODO: shouldn't the command cmd be printing the output, and not the package?
+// The app, config, host, and runtime sections all do this too. (otherwise we
+// should just combine the two packages). And why do we print the output here,
+// but print the error in main???
+func ListPools(configStore *config.Store, env string) error {
+	var envs []string
+	var err error
+
+	if env != "" {
+		envs = []string{env}
+	} else {
+		envs, err = configStore.ListEnvs()
+		if err != nil {
+			return err
+		}
+
+	}
+
+	columns := []string{"ENV | POOL | APPS "}
+
+	for _, env := range envs {
+
+		pools, err := configStore.ListPools(env)
+		if err != nil {
+			return fmt.Errorf("ERROR: cannot list pools: %s", err)
+		}
+
+		if len(pools) == 0 {
+			columns = append(columns, strings.Join([]string{
+				env,
+				"",
+				""}, " | "))
+			continue
+		}
+
+		for _, pool := range pools {
+
+			assigments, err := configStore.ListAssignments(env, pool)
+			if err != nil {
+				fmt.Printf("ERROR: cannot list pool assignments for %s/%s: %s", env, pool, err)
+			}
+
+			columns = append(columns, strings.Join([]string{
+				env,
+				pool,
+				strings.Join(assigments, ",")}, " | "))
+
+		}
+	}
+	fmt.Println(columnize.SimpleFormat(columns))
+	return nil
+}
+
+// Create a pool for an environment
+func PoolCreate(configStore *config.Store, env, pool string) error {
+	exists, err := configStore.PoolExists(env, pool)
+	if err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("pool '%s' exists", pool)
+	}
+
+	_, err = configStore.CreatePool(pool, env)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func PoolDelete(configStore *config.Store, env, pool string) error {
+	exists, err := configStore.PoolExists(env, pool)
+	if err != nil {
+		return err
+	} else if !exists {
+		return fmt.Errorf("pool '%s' does not exist", pool)
+	}
+
+	empty, err := configStore.DeletePool(pool, env)
+	if err != nil {
+		return err
+	}
+
+	if !empty {
+		return fmt.Errorf("pool '%s' is not epmty", pool)
+	}
+	return nil
+}

--- a/commander/runtime.go
+++ b/commander/runtime.go
@@ -1,11 +1,11 @@
 package commander
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/litl/galaxy/config"
-	"github.com/litl/galaxy/log"
 	"github.com/litl/galaxy/utils"
 	"github.com/ryanuber/columnize"
 )
@@ -68,7 +68,7 @@ func RuntimeList(configStore *config.Store, app, env, pool string) error {
 		}
 	}
 	output := columnize.SimpleFormat(columns)
-	log.Println(output)
+	fmt.Println(output)
 	return nil
 
 }


### PR DESCRIPTION
- Start moving remaing functionality from galaxy to commander.
- Stop using a logger to print formatted output with the commander
  package. The commander package probably shouldn't print anything at
  all, but we can address that later