### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-- 1.4
-- tip
+- 1.5
 install:
 - go get github.com/robfig/glock
 - make deps


### PR DESCRIPTION
- Use go1.5
- remove go tip, since it breaks go-dockerclient which has a vendor
  directory in the source