### PR TITLE
add maintenance mode support to Galaxy

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -3,7 +3,6 @@ github.com/codegangsta/cli 50c77ecec0068c9aef9d90ae0fd0fdf410041da3
 github.com/fatih/color 95b468b5f34882796c597b718955603a584a9bd4
 github.com/fsouza/go-dockerclient 9997944ef0571631d04f598c6d31bdbe0915d5a0
 github.com/garyburd/redigo 535138d7bcd717d6531c701ef5933d98b1866257
-github.com/goamz/goamz a1da1b724496ac803aabd4898e15e74535d68ee0
 github.com/hashicorp/consul a02ba028156e7b4db52a1e090394568aa4a3def8
-github.com/litl/shuttle f2398ad6626694603accb6d34183aedee79336df
+github.com/litl/shuttle 2f96e5ace416402767cb59dca49e788f983fe35e
 github.com/ryanuber/columnize 44cb4788b2ec3c3d158dd3d1b50aba7d66f4b59a

--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -914,15 +914,17 @@ func main() {
 		var c string
 		var vhost string
 		var port string
+		var maint string
 		runtimeFs := flag.NewFlagSet("runtime:set", flag.ExitOnError)
 		runtimeFs.IntVar(&ps, "ps", 0, "Number of instances to run across all hosts")
 		runtimeFs.StringVar(&m, "m", "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
 		runtimeFs.StringVar(&c, "c", "", "CPU shares (relative weight)")
 		runtimeFs.StringVar(&vhost, "vhost", "", "Virtual host for HTTP routing")
 		runtimeFs.StringVar(&port, "port", "", "Service port for service discovery")
+		runtimeFs.StringVar(&maint, "maint", "", "Enable or disable maintenance mode")
 
 		runtimeFs.Usage = func() {
-			println("Usage: commander runtime:set [-ps 1] [-m 100m] [-c 512] [-vhost x.y.z] [-port 8000] <app>\n")
+			println("Usage: commander runtime:set [-ps 1] [-m 100m] [-c 512] [-vhost x.y.z] [-port 8000] [-maint false] <app>\n")
 			println("    Set container runtime policies\n")
 			println("Options:\n")
 			runtimeFs.PrintDefaults()
@@ -952,11 +954,12 @@ func main() {
 		}
 
 		updated, err := commander.RuntimeSet(configStore, app, env, pool, commander.RuntimeOptions{
-			Ps:          ps,
-			Memory:      m,
-			CPUShares:   c,
-			VirtualHost: vhost,
-			Port:        port,
+			Ps:              ps,
+			Memory:          m,
+			CPUShares:       c,
+			VirtualHost:     vhost,
+			Port:            port,
+			MaintenanceMode: maint,
 		})
 		if err != nil {
 			log.Fatalf("ERROR: %s", err)

--- a/commander/runtime.go
+++ b/commander/runtime.go
@@ -11,11 +11,12 @@ import (
 )
 
 type RuntimeOptions struct {
-	Ps          int
-	Memory      string
-	CPUShares   string
-	VirtualHost string
-	Port        string
+	Ps              int
+	Memory          string
+	CPUShares       string
+	VirtualHost     string
+	Port            string
+	MaintenanceMode string
 }
 
 func RuntimeList(configStore *config.Store, app, env, pool string) error {
@@ -30,7 +31,7 @@ func RuntimeList(configStore *config.Store, app, env, pool string) error {
 		}
 	}
 
-	columns := []string{"ENV | NAME | POOL | PS | MEM | VHOSTS | PORT"}
+	columns := []string{"ENV | NAME | POOL | PS | MEM | VHOSTS | PORT | MAINT"}
 
 	for _, env := range envs {
 
@@ -63,6 +64,7 @@ func RuntimeList(configStore *config.Store, app, env, pool string) error {
 					mem,
 					appCfg.Env()["VIRTUAL_HOST"],
 					appCfg.Env()["GALAXY_PORT"],
+					fmt.Sprint(appCfg.GetMaintenanceMode(p)),
 				}, " | "))
 			}
 		}
@@ -101,6 +103,15 @@ func RuntimeSet(configStore *config.Store, app, env, pool string, options Runtim
 
 	if options.Port != "" {
 		cfg.EnvSet("GALAXY_PORT", options.Port)
+	}
+
+	if options.MaintenanceMode != "" {
+		b, err := strconv.ParseBool(options.MaintenanceMode)
+		if err != nil {
+			return false, err
+		}
+
+		cfg.SetMaintenanceMode(pool, b)
 	}
 
 	return configStore.UpdateApp(cfg, env)

--- a/config/app_config.go
+++ b/config/app_config.go
@@ -28,6 +28,8 @@ type App interface {
 	GetMemory(pool string) string
 	SetCPUShares(pool string, cpu string)
 	GetCPUShares(pool string) string
+	SetMaintenanceMode(pool string, maint bool)
+	GetMaintenanceMode(pool string) bool
 }
 
 type AppConfig struct {
@@ -194,4 +196,15 @@ func (s *AppConfig) SetCPUShares(pool string, cpu string) {
 func (s *AppConfig) GetCPUShares(pool string) string {
 	key := fmt.Sprintf("%s-cpu", pool)
 	return s.runtimeVMap.Get(key)
+}
+
+func (s *AppConfig) SetMaintenanceMode(pool string, maint bool) {
+	key := fmt.Sprintf("%s-maint", pool)
+	s.runtimeVMap.SetVersion(key, fmt.Sprint(maint), s.nextID())
+}
+
+func (s *AppConfig) GetMaintenanceMode(pool string) bool {
+	key := fmt.Sprintf("%s-maint", pool)
+	maint, _ := strconv.ParseBool(s.runtimeVMap.Get(key))
+	return maint
 }

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,9 @@ type AppAssignment struct {
 	// Minimum number of instances to keep running during a deploy or restart.
 	// Default is 1 if Instances is > 1, else 0.
 	MinInstances int
+
+	// Whether this app is in maintenance mode
+	MaintenanceMode bool
 }
 
 //
@@ -185,6 +188,16 @@ func (a *AppDefinition) SetCPUShares(pool string, cpu string) {
 func (a *AppDefinition) GetCPUShares(pool string) string {
 	i := a.assignment(pool)
 	return strconv.Itoa(a.Assignments[i].CPU)
+}
+
+func (a *AppDefinition) SetMaintenanceMode(pool string, maint bool) {
+	i := a.assignment(pool)
+	a.Assignments[i].MaintenanceMode = maint
+}
+
+func (a *AppDefinition) GetMaintenanceMode(pool string) bool {
+	i := a.assignment(pool)
+	return a.Assignments[i].MaintenanceMode
 }
 
 // TODO: This is to make it easier to refactor in this new config.

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -105,7 +105,7 @@ func RegisterAll(serviceRuntime *runtime.ServiceRuntime, configStore *config.Sto
 
 	}
 
-	registerShuttle(configStore, env, shuttleAddr)
+	registerShuttle(configStore, env, pool, shuttleAddr)
 }
 
 func Register(serviceRuntime *runtime.ServiceRuntime, configStore *config.Store, env, pool, hostIP, shuttleAddr string) {
@@ -135,7 +135,7 @@ func Register(serviceRuntime *runtime.ServiceRuntime, configStore *config.Store,
 
 				log.Printf("Registered %s running as %s for %s%s", strings.TrimPrefix(reg.ContainerName, "/"),
 					reg.ContainerID[0:12], reg.Name, locationAt(reg))
-				registerShuttle(configStore, env, shuttleAddr)
+				registerShuttle(configStore, env, pool, shuttleAddr)
 			case "die", "stop":
 				reg, err := configStore.UnRegisterService(env, pool, hostIP, ce.Container)
 				if err != nil {

--- a/discovery/shuttle.go
+++ b/discovery/shuttle.go
@@ -13,7 +13,7 @@ var (
 	client *shuttle.Client
 )
 
-func registerShuttle(configStore *config.Store, env, shuttleAddr string) {
+func registerShuttle(configStore *config.Store, env, pool, shuttleAddr string) {
 	if client == nil {
 		return
 	}
@@ -66,6 +66,14 @@ func registerShuttle(configStore *config.Store, env, shuttleAddr string) {
 		if len(errorPages) > 0 {
 			service.ErrorPages = errorPages
 		}
+
+		app, err := configStore.GetApp(service.Name, env)
+		if err != nil {
+			log.Errorf("ERROR: Unable to get app for service %s: %s", service.Name, err)
+			continue
+		}
+
+		service.MaintenanceMode = app.GetMaintenanceMode(pool)
 	}
 
 	for _, service := range backends {


### PR DESCRIPTION
Set with `commander runtime -maint=<true|false> <app>`.  This flips the
bit in shuttle (see litl/shuttle#22), so this depends on a recent
revision of shuttle.

Unfortunately since this is a configuration change it requires a service
restart.  That might be something to optimize in the future.

Fixes #123.