### PR TITLE
- Use docker's syslog driver for logging

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml f87ce853111478914f0bcffa34d43a93643e6eda
 github.com/codegangsta/cli 50c77ecec0068c9aef9d90ae0fd0fdf410041da3
 github.com/fatih/color 95b468b5f34882796c597b718955603a584a9bd4
-github.com/fsouza/go-dockerclient 9997944ef0571631d04f598c6d31bdbe0915d5a0
+github.com/fsouza/go-dockerclient 64c100a0b566fb3569431b9416eb5a794a322981
 github.com/garyburd/redigo 535138d7bcd717d6531c701ef5933d98b1866257
 github.com/hashicorp/consul a02ba028156e7b4db52a1e090394568aa4a3def8
 github.com/litl/shuttle 2f96e5ace416402767cb59dca49e788f983fe35e

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -716,6 +716,10 @@ func (s *ServiceRuntime) Start(env, pool string, appCfg config.App) (*docker.Con
 			Name:              "on-failure",
 			MaximumRetryCount: 16,
 		},
+		LogConfig: docker.LogConfig{
+			Type:   "syslog",
+			Config: map[string]string{"syslog-tag": appCfg.Version()},
+		},
 	}
 
 	if s.dns != "" {


### PR DESCRIPTION
- Log to syslog, using syslog tags for app name and version
- Requires updating go-dockerclient. This also fixes the vendor
  directory problem in that repo.