### PR TITLE
Logs were using container name previously

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -718,7 +718,7 @@ func (s *ServiceRuntime) Start(env, pool string, appCfg config.App) (*docker.Con
 		},
 		LogConfig: docker.LogConfig{
 			Type:   "syslog",
-			Config: map[string]string{"syslog-tag": appCfg.Version()},
+			Config: map[string]string{"syslog-tag": containerName},
 		},
 	}
 


### PR DESCRIPTION
- the app name is unnecessary