### PR TITLE
Don't fail on VersionID mismatch

### DIFF
--- a/cmd/commander/main.go
+++ b/cmd/commander/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	golog "log"
@@ -124,10 +123,8 @@ func pullImage(appCfg config.App) (*docker.Image, error) {
 	}
 
 	if image.ID != appCfg.VersionID() && len(appCfg.VersionID()) > 12 {
-		log.Errorf("ERROR: Pulled image for %s does not match expected ID. Expected: %s: Got: %s",
-			appCfg.Version(),
-			image.ID[0:12], appCfg.VersionID()[0:12])
-		return nil, errors.New(fmt.Sprintf("failed to pull image ID %s", appCfg.VersionID()[0:12]))
+		log.Errorf("WARNING: Pulled image for %s does not match expected ID. Expected: %s: Got: %s",
+			appCfg.Version(), image.ID[0:12], appCfg.VersionID()[0:12])
 	}
 
 	log.Printf("Pulled %s\n", appCfg.Version())

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -207,9 +207,7 @@ func (s *ServiceRuntime) Stop(appCfg config.App) error {
 
 	for _, container := range containers {
 		cenv := s.EnvFor(container)
-		if cenv["GALAXY_APP"] == appCfg.Name() &&
-			cenv["GALAXY_VERSION"] == strconv.FormatInt(appCfg.ID(), 10) &&
-			appCfg.VersionID() == container.Image {
+		if cenv["GALAXY_APP"] == appCfg.Name() && cenv["GALAXY_VERSION"] == strconv.FormatInt(appCfg.ID(), 10) {
 			return s.stopContainer(container)
 		}
 	}


### PR DESCRIPTION
- If the registry isn't returning the same image that galaxy thinks
  should be running, then it's more likely that galaxy is running the
  wrong image.
- Remove the VersionID check from runtime.Stop so we can still stop any
  containers that may not have the right VersionID.
- Turn the fatal error in commander into a warning when the version
  don't match, so that the current image can be deployed.