### PR TITLE
Work with change to content-addressable IDs

### DIFF
--- a/commander/app.go
+++ b/commander/app.go
@@ -130,7 +130,7 @@ func AppDeploy(configStore *config.Store, serviceRuntime *runtime.ServiceRuntime
 	}
 
 	svcCfg.SetVersion(version)
-	svcCfg.SetVersionID(image.ID)
+	svcCfg.SetVersionID(utils.StripSHA(image.ID))
 
 	updated, err := configStore.UpdateApp(svcCfg, env)
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -172,3 +172,8 @@ func ParseMemory(mem string) (int64, error) {
 	}
 	return i * multiplier, nil
 }
+
+// strip the leading sha256: from content adressable images
+func StripSHA(s string) string {
+	return strings.TrimPrefix(s, "sha256:")
+}


### PR DESCRIPTION
- Strip the leading "sha256:" from content-addressable images to match
  the displayed IDs.
- Only warn if an image is pulled where the image ID doesn't match the
  recorded VersionID. Move warning to the code that starts the service.
- Don't stop containers when the image ID doesn't match. If the config
  version matches, it's the right container. If the image doesn't match,
  we'll still get warnings when checking for the latest image, and can
  fix by redeploying a new config.
- Don't InspectImage before pulling, since PullImage will do the same.
- Don't pull every 10s, since the service check will pull again.
- Warn when a contaner dies and is automatically restarted.
- Periodically warn when a container's image doesn't match the config.