### PR TITLE
changes for Docker 0.12 compatibility

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -268,7 +268,7 @@ func (s *ServiceRuntime) StopOldVersion(appCfg config.App, limit int) error {
 
 		image, err := s.InspectImage(container.Image)
 		if err != nil {
-			log.Errorf("ERROR: Unable to inspect image: %s", container.Image)
+			log.Errorf("ERROR: Unable to inspect image %s: %s", container.Image, err)
 			continue
 		}
 


### PR DESCRIPTION
Passing HostConfig in to StartContainer has been deprecated since 0.10
and was removed in 0.12.  Pass HostConfig in at container creation time
instead.

`syslog-tag` has been deprecated since 0.9 and removed in 0.12.  It's
been merged into the generic cross-log-driver `tag` field instead.
